### PR TITLE
Allocate less memory for Vagrant virtualbox VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
         box.vm.provider 'virtualbox' do |vb|
             vb.customize ["modifyvm", :id, "--natnet1", "172.31.9/24"]
             vb.gui = false
-            vb.memory = 4096
+            vb.memory = 1536
             vb.customize ["modifyvm", :id, "--ioapic", "on"]
             vb.customize ["modifyvm", :id, "--hpet", "on"]
         end
@@ -61,7 +61,7 @@ SCRIPT
         box.vm.provider 'virtualbox' do |vb|
             vb.customize ["modifyvm", :id, "--natnet1", "172.31.9/24"]
             vb.gui = false
-            vb.memory = 4096
+            vb.memory = 1536
             vb.customize ["modifyvm", :id, "--ioapic", "on"]
             vb.customize ["modifyvm", :id, "--hpet", "on"]
         end
@@ -120,7 +120,7 @@ SCRIPT
         box.vm.provider 'virtualbox' do |vb|
             vb.customize ["modifyvm", :id, "--natnet1", "172.31.9/24"]
             vb.gui = false
-            vb.memory = 4096
+            vb.memory = 1024
             vb.customize ["modifyvm", :id, "--ioapic", "on"]
             vb.customize ["modifyvm", :id, "--hpet", "on"]
         end


### PR DESCRIPTION
Each VM was allocated 4096 megabytes of memory. Based on practical tests 1536
megabytes is enough for bootstrapping servers - swap is touched only for a very
brief period during setup. IPA client VM seems to be content with 1024
megabytes.

This is changes is done to allow using Vagrant on computers that have lots of virtual machines running, or which have a fairly limited amount of memory to start with.