### PR TITLE
Split Vagrant provisioning tasks into separate scripts

### DIFF
--- a/vagrant/common.sh
+++ b/vagrant/common.sh
@@ -2,7 +2,8 @@
 echo I am provisioning...
 export FACTER_is_vagrant='true'
 rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
-yum install -y puppet-agent
+yum install -y puppet-agent yum-utils
+yum-config-manager --save --setopt=puppetlabs-pc1.skip_if_unavailable=true
 export PATH=$PATH:/opt/puppetlabs/bin
 puppet module install puppetlabs-concat
 puppet module install puppetlabs-stdlib

--- a/vagrant/common.sh
+++ b/vagrant/common.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+echo I am provisioning...
+export FACTER_is_vagrant='true'
+rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
+yum install -y puppet-agent
+export PATH=$PATH:/opt/puppetlabs/bin
+puppet module install puppetlabs-concat
+puppet module install puppetlabs-stdlib
+puppet module install crayfishx-firewalld
+puppet module install puppet-selinux
+puppet module install saz-resolv_conf
+if [ -d /tmp/modules/easy_ipa ]; then rm -rf /tmp/modules/easy_ipa; fi
+mkdir -p /tmp/modules/easy_ipa
+cp -r /vagrant/* /tmp/modules/easy_ipa

--- a/vagrant/ipa-client-1.sh
+++ b/vagrant/ipa-client-1.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+puppet apply --modulepath '/tmp/modules:/etc/puppetlabs/code/environments/production/modules' -e "\
+  class { 'resolv_conf':\
+    nameservers => ['192.168.44.35'],\
+  }"
+puppet apply --modulepath '/tmp/modules:/etc/puppetlabs/code/environments/production/modules' -e "\
+  class {'::easy_ipa':\
+    ipa_role => 'client',\
+    domain => 'vagrant.example.lan',\
+    domain_join_password => 'vagrant123',\
+    install_epel => true,\
+    ipa_master_fqdn => 'ipa-server-1.vagrant.example.lan',\
+  }"

--- a/vagrant/ipa-server-1.sh
+++ b/vagrant/ipa-server-1.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+puppet apply --modulepath '/tmp/modules:/etc/puppetlabs/code/environments/production/modules' -e "\
+  class {'::easy_ipa':\
+    ipa_role => 'master',\
+    domain => 'vagrant.example.lan',\
+    ipa_server_fqdn => 'ipa-server-1.vagrant.example.lan',\
+    admin_password => 'vagrant123',\
+    directory_services_password => 'vagrant123',\
+    install_ipa_server => true,\
+    ip_address => '192.168.44.35',\
+    enable_ip_address => true,\
+    enable_hostname => true,\
+    manage_host_entry => true,\
+    install_epel => true,\
+    webui_disable_kerberos => true,\
+    webui_enable_proxy => true,\
+    webui_force_https => true,\
+}"

--- a/vagrant/ipa-server-1.sh
+++ b/vagrant/ipa-server-1.sh
@@ -15,4 +15,5 @@ puppet apply --modulepath '/tmp/modules:/etc/puppetlabs/code/environments/produc
     webui_disable_kerberos => true,\
     webui_enable_proxy => true,\
     webui_force_https => true,\
+    idstart => 14341,\
 }"

--- a/vagrant/ipa-server-2.sh
+++ b/vagrant/ipa-server-2.sh
@@ -21,4 +21,5 @@ puppet apply --modulepath '/tmp/modules:/etc/puppetlabs/code/environments/produc
     manage_host_entry => true,\
     install_epel => true,\
     ipa_master_fqdn => 'ipa-server-1.vagrant.example.lan',\
+    idstart => 14341,\
   }"

--- a/vagrant/ipa-server-2.sh
+++ b/vagrant/ipa-server-2.sh
@@ -1,0 +1,24 @@
+#/bin/sh
+puppet apply --modulepath '/tmp/modules:/etc/puppetlabs/code/environments/production/modules' -e "\
+  class { 'resolv_conf':\
+    nameservers => ['192.168.44.35'],\
+  }"
+puppet apply --modulepath '/tmp/modules:/etc/puppetlabs/code/environments/production/modules' -e "\
+  host {'ipa-server-1.vagrant.example.lan':\
+    ensure => present,\
+    ip => '192.168.44.35',\
+  }"
+puppet apply --modulepath '/tmp/modules:/etc/puppetlabs/code/environments/production/modules' -e "\
+  class {'::easy_ipa':\
+    ipa_role => 'replica',\
+    domain => 'vagrant.example.lan',\
+    ipa_server_fqdn => 'ipa-server-2.vagrant.example.lan',\
+    domain_join_password => 'vagrant123',\
+    install_ipa_server => true,\
+    ip_address => '192.168.44.36',\
+    enable_ip_address => true,\
+    enable_hostname => true,\
+    manage_host_entry => true,\
+    install_epel => true,\
+    ipa_master_fqdn => 'ipa-server-1.vagrant.example.lan',\
+  }"


### PR DESCRIPTION
This reduces redundancy as the same preparatory tasks (install puppet agent,
install puppet modules, prepare module path) do not have to be repeated for on
every Vagrant box. This also makes it easier to create custom Vagrantfiles, for
example if one wishes to use providers other than Virtualbox.