### PR TITLE
Add support for --allow-zone-overlap install parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,12 @@
 # `directory_services_password`
 #      (string) Password which will be passed into the ipa setup's parameter named "--ds-password".
 #
+# `allow_zone_overlap`
+#      (boolean) if set to true, allow creating of (reverse) zone even if the zone is already
+#                resolvable. Using this option is discouraged as it result in later problems with
+#                domain name. You may have to use this, though, when migrating existing DNS
+#                domains to FreeIPA.
+#
 # `autofs_package_name`
 #      (string) Name of the autofs package to install if enabled.
 #
@@ -149,6 +155,7 @@ class easy_ipa (
   String        $admin_password                     = '',
   String        $directory_services_password        = '',
   String        $autofs_package_name                = 'autofs',
+  Boolean       $allow_zone_overlap                 = false,
   Boolean       $client_install_ldaputils           = false,
   Boolean       $configure_dns_server               = true,
   Boolean       $configure_ntp                      = true,

--- a/manifests/install/server.pp
+++ b/manifests/install/server.pp
@@ -17,6 +17,12 @@ class easy_ipa::install::server {
 
   $server_install_cmd_opts_idstart = "--idstart=${easy_ipa::idstart}"
 
+  if $easy_ipa::allow_zone_overlap {
+    $server_install_cmd_opts_zone_overlap = '--allow-zone-overlap'
+  } else {
+    $server_install_cmd_opts_zone_overlap = ''
+  }
+
   if $easy_ipa::enable_hostname {
     $server_install_cmd_opts_hostname = "--hostname=${easy_ipa::ipa_server_fqdn}"
   } else {

--- a/manifests/install/server/master.pp
+++ b/manifests/install/server/master.pp
@@ -7,6 +7,7 @@ class easy_ipa::install::server::master {
   --domain=${easy_ipa::domain} \
   --admin-password='${easy_ipa::admin_password}' \
   --ds-password='${easy_ipa::directory_services_password}' \
+  ${easy_ipa::install::server::server_install_cmd_opts_zone_overlap} \
   ${easy_ipa::install::server::server_install_cmd_opts_setup_dns} \
   ${easy_ipa::install::server::server_install_cmd_opts_forwarders} \
   ${easy_ipa::install::server::server_install_cmd_opts_ip_address} \

--- a/manifests/install/server/replica.pp
+++ b/manifests/install/server/replica.pp
@@ -8,6 +8,7 @@ class easy_ipa::install::server::replica {
   --realm=${easy_ipa::final_realm} \
   --domain=${easy_ipa::domain} \
   --server=${easy_ipa::ipa_master_fqdn} \
+  ${easy_ipa::install::server::server_install_cmd_opts_zone_overlap} \
   ${easy_ipa::install::server::server_install_cmd_opts_setup_dns} \
   ${easy_ipa::install::server::server_install_cmd_opts_forwarders} \
   ${easy_ipa::install::server::server_install_cmd_opts_ip_address} \


### PR DESCRIPTION
This is useful/necessary when migrating existing domains to FreeIPA